### PR TITLE
Fixed parseResponse() bug

### DIFF
--- a/src/SparkFun_UHF_RFID_Reader.cpp
+++ b/src/SparkFun_UHF_RFID_Reader.cpp
@@ -673,6 +673,10 @@ uint8_t RFID::parseResponse(void)
     {
       return (RESPONSE_IS_UNKNOWN);
     }
+    else if (this.msg[1] == 0x0a) //temperature
+    {
+        return (RESPONSE_IS_TEMPERATURE);
+    }
     else //Full tag record
     {
       //This is a full tag response


### PR DESCRIPTION
Temperature Status messages were coming through as a Tag Read Data event, whose EPC was invalid (in my case, twelve zeros).

Now temperature messages can be sought from the message buffer after RESPONSE_IS_TEMPERATURE is returned by looking in `msg[14]`, which gives you a number in ºC.

Ref: AutoConfigTool_1.2-UserGuide_v02RevA.pdf, page 27